### PR TITLE
Make halfagg draft BIP3 compliant

### DIFF
--- a/half-aggregation.mediawiki
+++ b/half-aggregation.mediawiki
@@ -1,6 +1,16 @@
 <pre>
-  Title: Half-Aggregation of BIP 340 signatures
-  Status: EXPERIMENTAL
+  BIP: ?
+  Layer: Applications
+  Title: Half-Aggregation of BIP 340 Signatures
+  Authors: Tim Ruffing <crypto@timruffing.de>
+           Jonas Nick <jonas@n-ck.net>
+           Fabian Jahr <fjahr@protonmail.com>
+  Status: Draft
+  Type: Specification
+  Assigned: ?
+  License: BSD-3-Clause
+  Discussion: 2022-07-08: https://gnusha.org/pi/bitcoindev/33f275c2-06b1-4b4a-2a75-cafe36836503%40gmail.com/
+  Requires: 340
 </pre>
 
 == Introduction ==
@@ -13,7 +23,7 @@ The size of the resulting aggregate signature is approximately half of the combi
 
 === Copyright ===
 
-This document is licensed under the 3-clause BSD license.
+This document is licensed under the BSD-3-Clause License.
 
 === Motivation ===
 
@@ -51,7 +61,7 @@ In the best case, a full block would only have a single half-aggregate signature
 While this is attractive from the efficiency perspective, block-wide aggregation requires more research (and, in particular, special attention to handling
 [https://github.com/ElementsProject/cross-input-aggregation#half-aggregation-and-reorgs reorgs]).
 
-=== Design ===
+=== Rationale ===
 
 The idea for half-aggregation of Schnorr signatures was brought up in the context of block-wide signature aggregation [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014272.html by Tadge Dryja on the Bitcoin mailing list] in 2017.
 The scheme had a security flaw that was [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014306.html noticed] and [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014308.html fixed] shortly after by Russell O'Connor and Andrew Poelstra.


### PR DESCRIPTION
Part of an effort to get the halfagg draft ready for a bips repo pull request.

Since it is very likely that [BIP3](https://github.com/bitcoin/bips/blob/master/bip-0003.md) will be adopted very shortly, let's get it ready to comply with it's formate requirements.

I took the authors list from the much more recent [Frost DKG BIP draft](https://github.com/BlockstreamResearch/bip-frost-dkg).